### PR TITLE
Add Credentials Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ If no options are given, it will use these defaults:
 ```typescript
 {
     allowOrigin: '*',
-    allowHeaders: ['"Content-Type", "User-Agent", "Authorization", "Accept", "Prefer", "Prefer-Push", "Link"'],
-    allowMethods: ["DELETE", "GET", "PATCH", "POST", "PUT"],
-    exposeHeaders: ["Location", "Link"]
+    allowHeaders: ['Content-Type', 'User-Agent', 'Authorization', 'Accept', 'Prefer', 'Prefer-Push', 'Link'],
+    allowMethods: ['DELETE', 'GET', 'PATCH', 'POST', 'PUT'],
+    exposeHeaders: ['Location', 'Link'],
     credentials: false
 }
 ```

--- a/README.md
+++ b/README.md
@@ -29,18 +29,22 @@ app.use(cors({
     allowOrigin: '*',
     allowHeaders: ['Content-Type', 'Accept'],
     allowMethods: ['GET', 'POST'],
-    exposeHeaders: ['Link', 'Date']
+    exposeHeaders: ['Link', 'Date'],
+    credentials: true
 }));
 
 ```
 
 If no options are given, it will use these defaults:
 
-```
-allowOrigin: '*',
-allowHeaders: ['"Content-Type", "User-Agent", "Authorization", "Accept", "Prefer", "Prefer-Push", "Link"'],
-allowMethods: ["DELETE", "GET", "PATCH", "POST", "PUT"],
-exposeHeaders: ["Location", "Link"]
+```typescript
+{
+    allowOrigin: '*',
+    allowHeaders: ['"Content-Type", "User-Agent", "Authorization", "Accept", "Prefer", "Prefer-Push", "Link"'],
+    allowMethods: ["DELETE", "GET", "PATCH", "POST", "PUT"],
+    exposeHeaders: ["Location", "Link"]
+    credentials: false
+}
 ```
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ type CorsOptions = {
   allowHeaders: string[];
   allowMethods: string[];
   exposeHeaders: string[];
-  credentials?: boolean
+  credentials?: boolean;
 }
 
 export default function(optionsInit?: Partial<CorsOptions>): Middleware {
@@ -14,7 +14,7 @@ export default function(optionsInit?: Partial<CorsOptions>): Middleware {
   const options = generateOptions(optionsInit);
 
   if (options.credentials && options.allowHeaders.includes('*')) {
-    throw new Error('Access-Control-Allow-Headers cannot be * when Access-Control-Allow-Credentials is true')
+    throw new Error('Access-Control-Allow-Headers cannot be * when Access-Control-Allow-Credentials is true');
   }
 
   const allowedOrigins = Array.isArray(options.allowOrigin) ? options.allowOrigin : [options.allowOrigin];

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,16 @@ type CorsOptions = {
   allowHeaders: string[];
   allowMethods: string[];
   exposeHeaders: string[];
+  credentials?: boolean
 }
 
 export default function(optionsInit?: Partial<CorsOptions>): Middleware {
 
   const options = generateOptions(optionsInit);
+
+  if (options.credentials && options.allowHeaders.includes('*')) {
+    throw new Error('Access-Control-Allow-Headers cannot be * when Access-Control-Allow-Credentials is true')
+  }
 
   const allowedOrigins = Array.isArray(options.allowOrigin) ? options.allowOrigin : [options.allowOrigin];
 
@@ -40,6 +45,9 @@ export default function(optionsInit?: Partial<CorsOptions>): Middleware {
       if (options.exposeHeaders) {
         ctx.response.headers.set('Access-Control-Expose-Headers', options.exposeHeaders);
       }
+      if (options.credentials) {
+        ctx.response.headers.set('Access-Control-Allow-Credentials', 'true');
+      }
       if (ctx.method==='OPTIONS') {
         // This was a pre-flight request, so we no longer want to pass this request
         // down the stack.
@@ -61,6 +69,7 @@ function generateOptions(init?: Partial<CorsOptions> ) : CorsOptions {
     allowOrigin: init.allowOrigin || '*',
     allowHeaders: init.allowHeaders || ['Content-Type', 'User-Agent', 'Authorization', 'Accept', 'Prefer', 'Prefer-Push', 'Link'],
     allowMethods: init.allowMethods || ['DELETE', 'GET', 'PATCH', 'POST', 'PUT'],
-    exposeHeaders: init.exposeHeaders || ['Location', 'Link']
+    exposeHeaders: init.exposeHeaders || ['Location', 'Link'],
+    credentials: init.credentials || false
   };
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -172,6 +172,54 @@ describe('CORS middleware', () => {
 
   });
 
+  it('should support credentials', async () => {
+
+    const options = {
+      allowOrigin: '*',
+      allowHeaders: ['Content-Type', 'Accept'],
+      allowMethods: ['GET', 'POST'],
+      credentials: true
+    };
+    const headers = {
+      Origin: 'https://example.net'
+    };
+    const app = new Application;
+    app.use(cors(options));
+
+    app.use( ctx => {
+
+      ctx.status = 200;
+      ctx.response.body = 'hello world';
+
+    });
+
+    const response = await app.subRequest('GET', '/', headers);
+
+    expect(response.status).to.equal(200);
+    expect(response.headers.get('Access-Control-Allow-Origin')).to.equal('https://example.net');
+    expect(response.headers.get('Access-Control-Allow-Headers')).to.equal('Content-Type, Accept');
+    expect(response.headers.get('Access-Control-Allow-Methods')).to.equal('GET, POST');
+    expect(response.headers.get('Access-Control-Allow-Credentials')).to.equal('true');
+
+    expect(response.body).to.equal('hello world');
+
+  });
+
+  it('should prevent using credentials with * headers', async () => {
+
+    const options = {
+      allowOrigin: '*',
+      allowHeaders: ['*'],
+      allowMethods: ['GET', 'POST'],
+      credentials: true
+    };
+
+    expect(() => {
+      cors(options);
+    }).to.throw();
+
+  });
+
   it('should respond to OPTIONS request', async() => {
     const options = {
       allowOrigin: ['https://example.org'],


### PR DESCRIPTION
This adds a new option to include the `Access-Control-Allow-Credentials` header, which is needed to allow cookies. 

Since `Access-Control-Allow-Credentials=true` and `Access-Control-Allow-Headers=*` don't work together, I've also added an error to inform the user when they attempt to use them together.